### PR TITLE
fix dns_services config names

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -45,12 +45,12 @@
   'dns_checker':
     'skip_check_wait_seconds': null
     'dns_services':
-      - 'primary_ip': '1.1.1.1'
-        'secondary_ip': '1.0.0.1'
-      - 'primary_ip': '9.9.9.9'
-        'secondary_ip': '149.112.112.112'
-      - 'primary_ip': '8.8.8.8'
-        'secondary_ip': '8.8.4.4'
+      - 'primary': '1.1.1.1'
+        'secondary': '1.0.0.1'
+      - 'primary': '9.9.9.9'
+        'secondary': '149.112.112.112'
+      - 'primary': '8.8.8.8'
+        'secondary': '8.8.4.4'
   'providers':
     # If any provider is configured, the default will not be
     'http_01_internal':

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -117,10 +117,10 @@
       # internal dns usually has long cache and doesn't truly check propagation
       # if you don't want external dns checking, use skip_check above
       # primary and secondary should be for the same provider
-      - 'primary_ip': '208.67.222.222'
-        'secondary_ip': '208.67.220.220'
-      - 'primary_ip': '45.90.28.0'
-        'secondary_ip': '45.90.28.255'
+      - 'primary': '208.67.222.222'
+        'secondary': '208.67.220.220'
+      - 'primary': '45.90.28.0'
+        'secondary': '45.90.28.255'
 
   # Providers are critical to Cert Warden's function. These are how you verify control over
   # the domains you issue certificates for. You must have at least one provider.


### PR DESCRIPTION
this small patch fix dns_services config keys, because in documentation were incorrect key names