### PR TITLE
Feature: Download PKCS12 (PFX, P12) files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # acme.sh temp folder
 /scripts/linux/acme.sh/temp
+
+# temporary debug files
+__debug*

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.24.0
 	gopkg.in/yaml.v3 v3.0.1
+	software.sslmate.com/src/go-pkcs12 v0.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2569,3 +2569,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77Vzej
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
+software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
+software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/pkg/domain/app/router_make.go
+++ b/pkg/domain/app/router_make.go
@@ -147,6 +147,7 @@ func (app *Application) makeRouterAndRoutes() {
 	router.handleAPIRouteDownloadWithAPIKey(http.MethodGet, apiKeyDownloadUrlPath+"/privatecerts/:name", app.download.DownloadPrivateCertViaHeader)
 	router.handleAPIRouteDownloadWithAPIKey(http.MethodGet, apiKeyDownloadUrlPath+"/privatecertchains/:name", app.download.DownloadPrivateCertChainViaHeader)
 	router.handleAPIRouteDownloadWithAPIKey(http.MethodGet, apiKeyDownloadUrlPath+"/certrootchains/:name", app.download.DownloadCertRootChainViaHeader)
+	router.handleAPIRouteDownloadWithAPIKey(http.MethodGet, apiKeyDownloadUrlPath+"/pfx/:name", app.download.DownloadPfxViaHeader)
 
 	// download keys and certs - via URL routes
 	router.handleAPIRouteDownloadWithAPIKey(http.MethodGet, apiKeyDownloadUrlPath+"/privatekeys/:name/*apiKey", app.download.DownloadKeyViaUrl)
@@ -154,6 +155,7 @@ func (app *Application) makeRouterAndRoutes() {
 	router.handleAPIRouteDownloadWithAPIKey(http.MethodGet, apiKeyDownloadUrlPath+"/privatecerts/:name/*apiKey", app.download.DownloadPrivateCertViaUrl)
 	router.handleAPIRouteDownloadWithAPIKey(http.MethodGet, apiKeyDownloadUrlPath+"/privatecertchains/:name/*apiKey", app.download.DownloadPrivateCertChainViaUrl)
 	router.handleAPIRouteDownloadWithAPIKey(http.MethodGet, apiKeyDownloadUrlPath+"/certrootchains/:name/*apiKey", app.download.DownloadCertRootChainViaUrl)
+	router.handleAPIRouteDownloadWithAPIKey(http.MethodGet, apiKeyDownloadUrlPath+"/pfx/:name/*apiKey", app.download.DownloadPfxViaUrl)
 
 	// frontend (if enabled)
 	if *app.config.FrontendServe {

--- a/pkg/domain/download/out_pfx.go
+++ b/pkg/domain/download/out_pfx.go
@@ -1,0 +1,206 @@
+package download
+
+import (
+	"certwarden-backend/pkg/domain/orders"
+	"certwarden-backend/pkg/output"
+	"crypto/x509"
+	"encoding/base64"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/julienschmidt/httprouter"
+	"software.sslmate.com/src/go-pkcs12"
+)
+
+// modified Order to allow implementation of custom out functions
+// to properly output the desired content
+type pfxPrivateCertificateChain privateCertificateChain
+
+// pfxPrivateCertificateChain Output Methods
+
+func (pcc pfxPrivateCertificateChain) FilenameNoExt() string {
+	return pcc.Certificate.Name
+}
+
+func TrimIdentifiers(pem string) []byte {
+	trimParts := []string{
+		"-----BEGIN CERTIFICATE-----\n",
+		"-----BEGIN PRIVATE KEY-----\n",
+		"-----BEGIN RSA PRIVATE KEY-----\n",
+		"-----END CERTIFICATE-----\n",
+		"-----END PRIVATE KEY-----\n",
+		"-----END RSA PRIVATE KEY-----\n",
+		"-----BEGIN EC PRIVATE KEY-----\n",
+		"-----END EC PRIVATE KEY-----\n",
+	}
+
+	for _, part := range trimParts {
+		pem = strings.ReplaceAll(pem, part, "")
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(pem)
+	if err != nil {
+		return nil
+	}
+
+	return decoded
+}
+
+func ParsePrivateKey(byteval []byte) (interface{}, error) {
+	var res interface{}
+	var err error
+
+	res, err = x509.ParsePKCS1PrivateKey(byteval)
+	if err != nil {
+		res, err = x509.ParsePKCS8PrivateKey(byteval)
+		if err != nil {
+			res, err = x509.ParseECPrivateKey(byteval)
+		}
+	}
+
+	return res, err
+}
+
+// PfxContent returns the combined key + cert + chain pfx content
+func (pcc pfxPrivateCertificateChain) PfxContent() []byte {
+	certPem := orders.Order(pcc).PemContentNoChain()
+	certChainPem := orders.Order(pcc).PemContentChainOnly()
+	keyPem := pcc.FinalizedKey.PemContent()
+
+	certPemTrimmed := TrimIdentifiers(certPem)
+	keyPemTrimmed := TrimIdentifiers(keyPem)
+
+	fullChainPem := []*x509.Certificate{}
+
+	splitCertChainPem := strings.Split(certChainPem, "-----END CERTIFICATE-----\n")
+	for _, chainCert := range splitCertChainPem {
+		if len(chainCert) == 0 {
+			continue
+		}
+		trimmed := TrimIdentifiers(chainCert)
+		cert, err := x509.ParseCertificate(trimmed)
+		if err != nil {
+			return nil
+		}
+		fullChainPem = append(fullChainPem, cert)
+	}
+
+	x509cert, err := x509.ParseCertificate(certPemTrimmed)
+	if err != nil {
+		return nil
+	}
+
+	x509key, err := ParsePrivateKey(keyPemTrimmed)
+	if err != nil {
+		return nil
+	}
+
+	pfx, err := pkcs12.Modern.Encode(x509key, x509cert, fullChainPem, pcc.FinalizedKey.ApiKey)
+	if err != nil {
+		return nil
+	}
+
+	return pfx
+}
+
+func (pcc pfxPrivateCertificateChain) Modtime() time.Time {
+	// if key is nil, return 0 time since Pem output of thie type will fail anyway without a key
+	if pcc.FinalizedKey == nil {
+		return time.Time{}
+	}
+
+	// key time
+	keyModtime := pcc.FinalizedKey.Modtime()
+
+	// order (cert) time
+	certModtime := orders.Order(pcc).Modtime()
+
+	// return more recent of the two
+	if keyModtime.After(certModtime) {
+		return keyModtime
+	}
+	return certModtime
+}
+
+// end privateCertificateChain Output Methods
+
+// DownloadPfxViaHeader
+func (service *Service) DownloadPfxViaHeader(w http.ResponseWriter, r *http.Request) *output.Error {
+	// get cert name
+	params := httprouter.ParamsFromContext(r.Context())
+	certName := params.ByName("name")
+
+	// get apiKey from header
+	apiKeysCombined := getApiKeyFromHeader(w, r)
+
+	// fetch the private cert
+	privCert, err := service.getCertNewestPfx(certName, apiKeysCombined, false)
+	if err != nil {
+		return err
+	}
+
+	// return pem file to client
+	service.output.WritePfx(w, r, privCert)
+
+	return nil
+}
+
+// DownloadPfxViaUrl
+func (service *Service) DownloadPfxViaUrl(w http.ResponseWriter, r *http.Request) *output.Error {
+	// get cert name & apiKey
+	params := httprouter.ParamsFromContext(r.Context())
+	certName := params.ByName("name")
+
+	apiKeysCombined := getApiKeyFromParams(params)
+
+	// fetch the private cert
+	privCert, err := service.getCertNewestPfx(certName, apiKeysCombined, true)
+	if err != nil {
+		return err
+	}
+
+	// return pem file to client
+	service.output.WritePfx(w, r, privCert)
+
+	return nil
+}
+
+// getCertNewestPfx gets the appropriate order for the requested Cert and sets its type to
+// privateCertificateChain so the proper data is outputted.
+// To avoid unauthorized output of a key, both the certificate and key apiKeys must be provided. The format
+// for this is the certificate apikey appended to the private key's apikey using a '.' as a separator.
+// It also checks the apiKeyViaUrl property if the client is making a request with the apiKey in the Url.
+func (service *Service) getCertNewestPfx(certName string, apiKeysCombined string, apiKeyViaUrl bool) (pfxPrivateCertificateChain, *output.Error) {
+	// separate the apiKeys
+	apiKeys := strings.Split(apiKeysCombined, ".")
+
+	// error if not exactly 2 apiKeys
+	if len(apiKeys) != 2 {
+		return pfxPrivateCertificateChain{}, output.ErrUnauthorized
+	}
+
+	certApiKey := apiKeys[0]
+	keyApiKey := apiKeys[1]
+
+	// fetch the cert's newest valid order
+	order, err := service.getCertNewestValidOrder(certName, certApiKey, apiKeyViaUrl)
+	if err != nil {
+		return pfxPrivateCertificateChain{}, err
+	}
+
+	// confirm the private key is valid
+	if order.FinalizedKey == nil {
+		service.logger.Debug(errFinalizedKeyMissing)
+		return pfxPrivateCertificateChain{}, output.ErrNotFound
+	}
+
+	// validate the apiKey for the private key is correct
+	if order.FinalizedKey.ApiKey != keyApiKey {
+		service.logger.Debug(errWrongApiKey)
+		return pfxPrivateCertificateChain{}, output.ErrUnauthorized
+	}
+
+	// return pfx content
+	return pfxPrivateCertificateChain(order), nil
+}

--- a/pkg/output/pfx.go
+++ b/pkg/output/pfx.go
@@ -1,0 +1,39 @@
+package output
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"fmt"
+	"net/http"
+)
+
+// PfxObject is an interface for objects that can be written to the client as
+// PFX data. It contains all methods needed to do this.
+type PfxObject interface {
+	OutFile
+	PfxContent() []byte
+}
+
+// WritePem sends an object supporting PEM output to the client as the appropriate application type
+// Note: currently error is not possible
+func (service *Service) WritePfx(w http.ResponseWriter, r *http.Request, obj PfxObject) {
+	// get filename and log for auditing
+	filename := obj.FilenameNoExt() + ".pfx"
+	service.logger.Debugf("writing pfx %s to client %s", filename, r.RemoteAddr)
+
+	// get pem content and convert to Reader
+	pfxContent := obj.PfxContent()
+	contentReader := bytes.NewReader(pfxContent)
+
+	// Set Content-Type and Content-Disposition headers explicitly
+	w.Header().Set("Content-Type", "application/x-pkcs12")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
+
+	// calculate sha1 of the PfxContent and set as a simplistic ETag
+	w.Header().Set("ETag", fmt.Sprintf("\"%x\"", sha1.Sum(pfxContent)))
+
+	// do not write HTTP Status, ServeContent will handle this
+
+	// ServeContent (technically fielname is not needed here since Content-Type is set explicitly above)
+	http.ServeContent(w, r, filename, obj.Modtime(), contentReader)
+}


### PR DESCRIPTION
Allows downloading PFX files via the API in the same way you would download privateCertChain combinations (double API keys). 

Currently uses the API key for the private key for encrypting the PFX since technically only the private key is stored encrypted, but if that doesn't feel appropriate we could likely add some more functionality to set a custom password via the URL on download, or use the combined API key.

Note that this uses the modern format with proper encryption, and does not handle the legacy RC2 PKCS#12 files.