### PR TITLE
Fix OIDC Integration with Microsoft Entra ID

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -80,6 +80,9 @@
     # the redirect url should be the BACKEND host, with the path:
     # `/certwarden/api/v1/app/auth/oidc/callback`
     'api_redirect_uri': 'https://cw.example.com:4055/certwarden/api/v1/app/auth/oidc/callback'
+    # application URI - required for Microsoft Entra ID,
+    # this should match your application's 'Application ID URI'
+    'app_uri': 'api://12345678-1234-1234-1234-123456789abc'
 
 # Cert Warden update checking functionality to alert you when new versions are available
 'updater':

--- a/pkg/domain/app/auth/handlers_oidc.go
+++ b/pkg/domain/app/auth/handlers_oidc.go
@@ -178,29 +178,50 @@ func (service *Service) OIDCGetCallback(w http.ResponseWriter, r *http.Request) 
 		return nil
 	}
 
-	// Validate the required scopes were granted - https://datatracker.ietf.org/doc/html/rfc6749#section-3.3
-	// if the scope is omitted, spec requires scope to exactly match the request (i.e., scope was accepted and
-	// validation here isn't needed)
-	// i.e., this is the AUTHORIZATION step
-	responseScopeString, hasScope := oidcStateObj.oauth2Token.Extra("scope").(string)
-	if hasScope {
-		responseScopes := strings.Split(responseScopeString, " ")
-		for _, requiredScope := range oidcRequiredScopes {
-			found := false
-			for _, responseScope := range responseScopes {
-				if requiredScope == responseScope {
-					found = true
-					break
-				}
-			}
+	// Validate the required scopes were granted
+	// For Microsoft Entra ID:
+	// - OpenID Connect scopes (openid, profile, offline_access) are validated by token presence
+	// - Custom API scopes are in the scope claim
 
-			if !found {
-				service.logger.Infof("client %s: oidc user '%s' required scope '%s' was not granted", r.RemoteAddr, oidcStateObj.oidcIDToken.Subject, requiredScope)
-				// redirect to frontend to try again
-				http.Redirect(w, r, oidcUnauthorizedErrorURL(oidcStateObj.callerRedirectUrl).String(), http.StatusFound)
-				return nil
-			}
+	// Validate offline_access by checking for refresh token
+	if oidcStateObj.oauth2Token.RefreshToken == "" {
+		service.logger.Infof("client %s: oidc user '%s' required scope 'offline_access' was not granted (no refresh token)", r.RemoteAddr, oidcStateObj.oidcIDToken.Subject)
+		http.Redirect(w, r, oidcUnauthorizedErrorURL(oidcStateObj.callerRedirectUrl).String(), http.StatusFound)
+		return nil
+	}
+
+	// Validate profile scope by checking for standard profile claims
+	var profileClaims struct {
+		Name    string `json:"name"`
+		Subject string `json:"sub"`
+	}
+	if err := oidcStateObj.oidcIDToken.Claims(&profileClaims); err != nil || profileClaims.Name == "" || profileClaims.Subject == "" {
+		service.logger.Infof("client %s: oidc user '%s' required scope 'profile' was not granted (missing profile claims)", r.RemoteAddr, oidcStateObj.oidcIDToken.Subject)
+		http.Redirect(w, r, oidcUnauthorizedErrorURL(oidcStateObj.callerRedirectUrl).String(), http.StatusFound)
+		return nil
+	}
+
+	// Validate custom API scope (certwarden:superadmin)
+	responseScopeString, hasScope := oidcStateObj.oauth2Token.Extra("scope").(string)
+	if !hasScope {
+		service.logger.Infof("client %s: oidc token response missing scope claim", r.RemoteAddr)
+		http.Redirect(w, r, oidcUnauthorizedErrorURL(oidcStateObj.callerRedirectUrl).String(), http.StatusFound)
+		return nil
+	}
+
+	responseScopes := strings.Split(responseScopeString, " ")
+	found = false
+	for _, scope := range responseScopes {
+		if scope == oidcCertWardenScope {
+			found = true
+			break
 		}
+	}
+	if !found {
+		service.logger.Infof("client %s: oidc user '%s' required scope '%s' was not granted", r.RemoteAddr, oidcStateObj.oidcIDToken.Subject, oidcCertWardenScope)
+		// redirect to frontend to try again
+		http.Redirect(w, r, oidcUnauthorizedErrorURL(oidcStateObj.callerRedirectUrl).String(), http.StatusFound)
+		return nil
 	}
 
 	// update redirect uri to contain the state and code

--- a/pkg/domain/app/auth/handlers_oidc.go
+++ b/pkg/domain/app/auth/handlers_oidc.go
@@ -25,6 +25,12 @@ func (service *Service) OIDCGetLogin(w http.ResponseWriter, r *http.Request) *ou
 		return output.JsonErrNotFound(errors.New("auth: OIDC is not configured"))
 	}
 
+	// Check if OIDC provider is Microsoft Entra ID and app_uri is not set
+	if strings.Contains(service.oidc.oauth2Config.Endpoint.AuthURL, "login.microsoftonline.com") && 
+		oidcCertWardenScope == "certwarden:superadmin" {
+		service.logger.Warn("'app_uri' is not set in configuration. This is required for Microsoft Entra ID OIDC authentication to work properly.")
+	}
+
 	// Option 1: Finish login with state/code
 	stateVal := r.URL.Query().Get("state")
 	if stateVal != "" {

--- a/pkg/domain/app/auth/oidc.go
+++ b/pkg/domain/app/auth/oidc.go
@@ -23,13 +23,14 @@ var oidcRequiredScopes []string
 
 // setOIDCScopes sets the appropriate scopes based on the issuer URL
 func setOIDCScopes(issuerURL string, appURI string) {
-	if strings.Contains(issuerURL, "login.microsoftonline.com") {
-		// For Microsoft Entra ID (Azure AD), scope needs to be in format appURI/scope
-		oidcCertWardenScope = fmt.Sprintf("%s/certwarden:superadmin", appURI)
-	} else {
-		// Default scope format for other providers
-		oidcCertWardenScope = "certwarden:superadmin"
-	}
+	// Default scope format for all providers
+	oidcCertWardenScope = "certwarden:superadmin"
+
+	// For Microsoft Entra ID, the scope format requires the full application URI prefix
+    if strings.Contains(issuerURL, "login.microsoftonline.com") && appURI != "" {
+        oidcCertWardenScope = fmt.Sprintf("%s/certwarden:superadmin", appURI)
+    }
+
 	// Set the required scopes array
 	oidcRequiredScopes = []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, "profile", oidcCertWardenScope}
 }

--- a/pkg/domain/app/auth/oidc.go
+++ b/pkg/domain/app/auth/oidc.go
@@ -27,9 +27,9 @@ func setOIDCScopes(issuerURL string, appURI string) {
 	oidcCertWardenScope = "certwarden:superadmin"
 
 	// For Microsoft Entra ID, the scope format requires the full application URI prefix
-    if strings.Contains(issuerURL, "login.microsoftonline.com") && appURI != "" {
-        oidcCertWardenScope = fmt.Sprintf("%s/certwarden:superadmin", appURI)
-    }
+	if strings.Contains(issuerURL, "login.microsoftonline.com") && appURI != "" {
+		oidcCertWardenScope = fmt.Sprintf("%s/certwarden:superadmin", appURI)
+	}
 
 	// Set the required scopes array
 	oidcRequiredScopes = []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, "profile", oidcCertWardenScope}

--- a/pkg/domain/app/auth/oidc.go
+++ b/pkg/domain/app/auth/oidc.go
@@ -16,10 +16,23 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const oidcCertWardenScope = "certwarden:superadmin"
 const oidcPendingSessionMinExp = 5 * time.Minute
 
-var oidcRequiredScopes = []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, "profile", oidcCertWardenScope}
+var oidcCertWardenScope string
+var oidcRequiredScopes []string
+
+// setOIDCScopes sets the appropriate scopes based on the issuer URL
+func setOIDCScopes(issuerURL string, appURI string) {
+	if strings.Contains(issuerURL, "login.microsoftonline.com") {
+		// For Microsoft Entra ID (Azure AD), scope needs to be in format appURI/scope
+		oidcCertWardenScope = fmt.Sprintf("%s/certwarden:superadmin", appURI)
+	} else {
+		// Default scope format for other providers
+		oidcCertWardenScope = "certwarden:superadmin"
+	}
+	// Set the required scopes array
+	oidcRequiredScopes = []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, "profile", oidcCertWardenScope}
+}
 
 // oidcPendingSession tracks various bits of information across the different steps of the OIDC
 // autentication and authorization flow

--- a/pkg/domain/app/auth/service.go
+++ b/pkg/domain/app/auth/service.go
@@ -57,6 +57,7 @@ type Config struct {
 		ClientID       string `yaml:"client_id"`
 		ClientSecret   string `yaml:"client_secret"`
 		APIRedirectURI string `yaml:"api_redirect_uri"`
+		AppURI         string `yaml:"app_uri"`
 	} `yaml:"oidc"`
 }
 
@@ -117,6 +118,9 @@ func NewService(app App, cfg *Config) (*Service, error) {
 	if cfg.OIDC.IssuerURL != "" {
 		// context to use CW's http Client
 		oidcCtxWithHttpClient := oidc.ClientContext(app.GetShutdownContext(), app.GetHttpClient())
+
+		// Set up OIDC scopes based on the provider
+		setOIDCScopes(cfg.OIDC.IssuerURL, cfg.OIDC.AppURI)
 
 		// oidc provider
 		var err error


### PR DESCRIPTION
This pull request addresses the authentication failure encountered when integrating Cert Warden with Microsoft Entra ID as an OIDC provider (#12). The issue arises due to Microsoft Entra ID interpreting unqualified custom scopes as belonging to its default resource, Microsoft Graph, leading to errors such as:
```
AADSTS650053: The application 'Cert Warden' asked for scope 'certwarden:superadmin' that doesn't exist on the resource '00000003-0000-0000-c000-000000000000'. Contact the app vendor.
```

### Changes

1. Added support for Microsoft Entra ID's resource-based scope architecture:
    - Added dynamic scope formatting based on the OIDC provider
    - Added `app_uri` configuration parameter for Microsoft Entra ID integration
    - Added warning logs when `app_uri` is not configured for Microsoft Entra ID

1. Improved scope validation:
    - Standard OIDC scopes (openid, profile, offline_access) are validated by checking token/claim presence
    - Custom API scopes are validated in the scope claim
    - Additional logging for troubleshooting OIDC claims

### Technical Details

From my understanding, Microsoft Entra ID handles scopes differently from other OIDC providers:
1. It organizes scopes by resources (audiences)
3. Standard OIDC scopes belong to the core authentication resource and aren't included in the scope claim
4. Custom API scopes require the full Application ID URI prefix (e.g., `api://12345678-1234-1234-1234-123456789abc/certwarden:superadmin`)

The previous implementation assumed all providers would include all granted scopes in the scope claim. While this worked for most providers, it failed with Microsoft Entra ID. The new implementation:
- Validates standard OIDC scopes by checking their actual effects (token/claim presence)
- Separately validates custom API scopes in the scope claim

### Configuration Changes

Added new `app_uri` configuration option in the OIDC section:
```yaml
oidc:
  # ... existing config ...
  # application URI - required for Microsoft Entra ID,
  # this should match your application's 'Application ID URI'
  'app_uri': 'api://12345678-1234-1234-1234-123456789abc'
```

### Testing
- [x] Tested successful login with Microsoft Entra ID
- [ ] Verify existing OIDC providers still work

### References
- https://learn.microsoft.com/en-us/answers/questions/1636448/error-aadsts650053-the-application-xxxx-asked-for
- https://www.josephguadagno.net/2020/06/26/connecting-to-an-api-protected-by-microsoft-identity-platform

If you have any suggestions for improvements or notice any inaccuracies in this implementation, please feel free to make edits directly or provide feedback.