### PR TITLE
Make the OIDC superadmin scope configurable and validate only authorization scopes

### DIFF
--- a/config.changelog.md
+++ b/config.changelog.md
@@ -27,6 +27,12 @@ take advantage of.
 
 ## Log
 
+### [Unreleased]
+
+- Add optional `auth.oidc.superadmin_scope` to override the scope required for
+  OIDC superadmin access. This is not a breaking change and does not increment
+  `config_version`; an omitted or empty value defaults to `certwarden:superadmin`.
+
 ### [v0.14.1] - 2023.10.17
 
 - 2023.10.23

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -26,6 +26,8 @@
 'auth':
   'local':
     'enabled': true
+  'oidc':
+    'superadmin_scope': 'certwarden:superadmin'
 
 'updater':
   'auto_check': true

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -77,6 +77,9 @@
     # the idp provides your client id and secret
     'client_id': 'abcdABCD'
     'client_secret': '123456'
+    # the scope required for superadmin access; defaults to `certwarden:superadmin`
+    # Some providers require the exact, fully-qualified resource scope.
+    'superadmin_scope': 'certwarden:superadmin'
     # the redirect url should be the BACKEND host, with the path:
     # `/certwarden/api/v1/app/auth/oidc/callback`
     'api_redirect_uri': 'https://cw.example.com:4055/certwarden/api/v1/app/auth/oidc/callback'

--- a/pkg/domain/app/auth/handlers_oidc.go
+++ b/pkg/domain/app/auth/handlers_oidc.go
@@ -191,22 +191,12 @@ func (service *Service) OIDCGetCallback(w http.ResponseWriter, r *http.Request) 
 	// i.e., this is the AUTHORIZATION step
 	responseScopeString, hasScope := oidcStateObj.oauth2Token.Extra("scope").(string)
 	if hasScope {
-		responseScopes := strings.Split(responseScopeString, " ")
-		for _, requiredScope := range oidcRequiredScopes {
-			found := false
-			for _, responseScope := range responseScopes {
-				if requiredScope == responseScope {
-					found = true
-					break
-				}
-			}
-
-			if !found {
-				service.logger.Infof("client %s: oidc user '%s' required scope '%s' was not granted", r.RemoteAddr, oidcStateObj.oidcIDToken.Subject, requiredScope)
-				// redirect to frontend to try again
-				http.Redirect(w, r, oidcUnauthorizedErrorURL(oidcStateObj.callerRedirectUrl).String(), http.StatusFound)
-				return nil
-			}
+		missingScope := oidcMissingRequiredScope(responseScopeString, service.oidc.oauth2Config.Scopes)
+		if missingScope != "" {
+			service.logger.Infof("client %s: oidc user '%s' required scope '%s' was not granted", r.RemoteAddr, oidcStateObj.oidcIDToken.Subject, missingScope)
+			// redirect to frontend to try again
+			http.Redirect(w, r, oidcUnauthorizedErrorURL(oidcStateObj.callerRedirectUrl).String(), http.StatusFound)
+			return nil
 		}
 	}
 

--- a/pkg/domain/app/auth/handlers_oidc.go
+++ b/pkg/domain/app/auth/handlers_oidc.go
@@ -189,9 +189,15 @@ func (service *Service) OIDCGetCallback(w http.ResponseWriter, r *http.Request) 
 	// if the scope is omitted, spec requires scope to exactly match the request (i.e., scope was accepted and
 	// validation here isn't needed)
 	// i.e., this is the AUTHORIZATION step
-	responseScopeString, hasScope := oidcStateObj.oauth2Token.Extra("scope").(string)
+	responseScopeString, hasScope, scopeValid := oidcTokenResponseScope(oidcStateObj.oauth2Token)
+	if !scopeValid {
+		service.logger.Infof("client %s: oidc user '%s' token response scope did not assert to string", r.RemoteAddr, oidcStateObj.oidcIDToken.Subject)
+		// redirect to frontend to try again
+		http.Redirect(w, r, oidcUnauthorizedErrorURL(oidcStateObj.callerRedirectUrl).String(), http.StatusFound)
+		return nil
+	}
 	if hasScope {
-		missingScope := oidcMissingRequiredScope(responseScopeString, service.oidc.oauth2Config.Scopes)
+		missingScope := oidcMissingRequiredScope(responseScopeString, service.oidc.requiredAuthorizationScopes)
 		if missingScope != "" {
 			service.logger.Infof("client %s: oidc user '%s' required scope '%s' was not granted", r.RemoteAddr, oidcStateObj.oidcIDToken.Subject, missingScope)
 			// redirect to frontend to try again
@@ -252,17 +258,18 @@ func (service *Service) OIDCLoginFinalize(w http.ResponseWriter, r *http.Request
 		service.logger.Errorf("client %s: login failed oidc state's id_token did not assert to string", r.RemoteAddr)
 		return output.ErrJsonUnauthorized
 	}
-	scopeStr, ok := oidcStateObj.oauth2Token.Extra("scope").(string)
-	if !ok {
+	scopeStr, _, scopeValid := oidcTokenResponseScope(oidcStateObj.oauth2Token)
+	if !scopeValid {
 		service.logger.Errorf("client %s: login failed oidc state's scope did not assert to string", r.RemoteAddr)
 		return output.ErrJsonUnauthorized
 	}
 
 	// make extra func obj
 	extraFuncs := &oidcExtraFuncs{
-		ctxWithHttpClient: service.oidc.ctxWithHttpClient,
-		cfg:               service.oidc.oauth2Config,
-		idTokenVerifier:   service.oidc.idTokenVerifier,
+		ctxWithHttpClient:           service.oidc.ctxWithHttpClient,
+		cfg:                         service.oidc.oauth2Config,
+		requiredAuthorizationScopes: service.oidc.requiredAuthorizationScopes,
+		idTokenVerifier:             service.oidc.idTokenVerifier,
 		token: &expectedToken{
 			AccessToken:  oidcStateObj.oauth2Token.AccessToken,
 			RefreshToken: oidcStateObj.oauth2Token.RefreshToken,

--- a/pkg/domain/app/auth/oidc.go
+++ b/pkg/domain/app/auth/oidc.go
@@ -19,12 +19,20 @@ import (
 const oidcDefaultSuperadminScope = "certwarden:superadmin"
 const oidcPendingSessionMinExp = 5 * time.Minute
 
-func oidcScopes(superadminScope string) []string {
+func oidcSuperadminScope(superadminScope string) string {
 	if superadminScope == "" {
-		superadminScope = oidcDefaultSuperadminScope
+		return oidcDefaultSuperadminScope
 	}
 
-	return []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, "profile", superadminScope}
+	return superadminScope
+}
+
+func oidcRequestedScopes(superadminScope string) []string {
+	return []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, "profile", oidcSuperadminScope(superadminScope)}
+}
+
+func oidcRequiredAuthorizationScopes(superadminScope string) []string {
+	return []string{oidcSuperadminScope(superadminScope)}
 }
 
 func oidcMissingRequiredScope(grantedScopes string, requiredScopes []string) string {
@@ -44,6 +52,16 @@ func oidcMissingRequiredScope(grantedScopes string, requiredScopes []string) str
 	}
 
 	return ""
+}
+
+func oidcTokenResponseScope(token *oauth2.Token) (scope string, present, valid bool) {
+	scopeValue := token.Extra("scope")
+	if scopeValue == nil {
+		return "", false, true
+	}
+
+	scope, valid = scopeValue.(string)
+	return scope, true, valid
 }
 
 // oidcPendingSession tracks various bits of information across the different steps of the OIDC
@@ -93,10 +111,11 @@ type expectedToken struct {
 
 // oidcExtraFuncs implements session manager's extraFuncs interface
 type oidcExtraFuncs struct {
-	ctxWithHttpClient context.Context
-	cfg               *oauth2.Config
-	idTokenVerifier   *oidc.IDTokenVerifier
-	token             *expectedToken
+	ctxWithHttpClient           context.Context
+	cfg                         *oauth2.Config
+	requiredAuthorizationScopes []string
+	idTokenVerifier             *oidc.IDTokenVerifier
+	token                       *expectedToken
 
 	mu sync.Mutex
 }
@@ -166,7 +185,7 @@ func (oef *oidcExtraFuncs) RefreshCheck() error {
 
 	// Validate the required scopes were granted
 	if t.Scope != "" {
-		missingScope := oidcMissingRequiredScope(t.Scope, oef.cfg.Scopes)
+		missingScope := oidcMissingRequiredScope(t.Scope, oef.requiredAuthorizationScopes)
 		if missingScope != "" {
 			return fmt.Errorf("oidc refresh failed, required scope '%s' was not granted", missingScope)
 		}

--- a/pkg/domain/app/auth/oidc.go
+++ b/pkg/domain/app/auth/oidc.go
@@ -16,10 +16,35 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const oidcCertWardenScope = "certwarden:superadmin"
+const oidcDefaultSuperadminScope = "certwarden:superadmin"
 const oidcPendingSessionMinExp = 5 * time.Minute
 
-var oidcRequiredScopes = []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, "profile", oidcCertWardenScope}
+func oidcScopes(superadminScope string) []string {
+	if superadminScope == "" {
+		superadminScope = oidcDefaultSuperadminScope
+	}
+
+	return []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, "profile", superadminScope}
+}
+
+func oidcMissingRequiredScope(grantedScopes string, requiredScopes []string) string {
+	responseScopes := strings.Split(grantedScopes, " ")
+	for _, requiredScope := range requiredScopes {
+		found := false
+		for _, responseScope := range responseScopes {
+			if requiredScope == responseScope {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return requiredScope
+		}
+	}
+
+	return ""
+}
 
 // oidcPendingSession tracks various bits of information across the different steps of the OIDC
 // autentication and authorization flow
@@ -141,19 +166,9 @@ func (oef *oidcExtraFuncs) RefreshCheck() error {
 
 	// Validate the required scopes were granted
 	if t.Scope != "" {
-		responseScopes := strings.Split(t.Scope, " ")
-		for _, requiredScope := range oidcRequiredScopes {
-			found := false
-			for _, responseScope := range responseScopes {
-				if requiredScope == responseScope {
-					found = true
-					break
-				}
-			}
-
-			if !found {
-				return fmt.Errorf("oidc refresh failed, required scope '%s' was not granted", requiredScope)
-			}
+		missingScope := oidcMissingRequiredScope(t.Scope, oef.cfg.Scopes)
+		if missingScope != "" {
+			return fmt.Errorf("oidc refresh failed, required scope '%s' was not granted", missingScope)
 		}
 	}
 

--- a/pkg/domain/app/auth/oidc_test.go
+++ b/pkg/domain/app/auth/oidc_test.go
@@ -1,9 +1,18 @@
 package auth
 
 import (
+	"certwarden-backend/pkg/datatypes/safemap"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
+	"github.com/coreos/go-oidc/v3/oidc"
+	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v3"
 )
@@ -26,7 +35,7 @@ func TestNewOIDCOAuth2ConfigUsesDefaultSuperadminScope(t *testing.T) {
 }
 
 func TestNewOIDCOAuth2ConfigUsesConfiguredSuperadminScope(t *testing.T) {
-	const customScope = "api://bb61c7e1-3af1-4b35-b0d2-1cbe60913ba2/certwarden:superadmin"
+	const customScope = "api://example-app/certwarden:superadmin"
 
 	cfg := new(Config)
 	err := yaml.Unmarshal([]byte("oidc:\n  superadmin_scope: \""+customScope+"\"\n"), cfg)
@@ -48,39 +57,324 @@ func TestNewOIDCOAuth2ConfigUsesConfiguredSuperadminScope(t *testing.T) {
 	}
 }
 
-func TestOIDCMissingRequiredScopeUsesConfiguredSuperadminScope(t *testing.T) {
-	const customScope = "api://bb61c7e1-3af1-4b35-b0d2-1cbe60913ba2/certwarden:superadmin"
-	cfg := new(Config)
-	cfg.OIDC.SuperadminScope = customScope
-	oauth2Cfg := newOIDCOAuth2Config(cfg, oauth2.Endpoint{})
-
+func TestOIDCRequiredAuthorizationScopes(t *testing.T) {
+	const customScope = "api://example-app/certwarden:superadmin"
 	tests := []struct {
-		name          string
-		grantedScopes string
-		wantMissing   string
+		name            string
+		configuredScope string
+		grantedScopes   string
+		wantMissing     string
 	}{
 		{
-			name:          "custom scope granted",
-			grantedScopes: "openid offline_access profile " + customScope,
+			name:            "openid omitted",
+			configuredScope: customScope,
+			grantedScopes:   "profile offline_access " + customScope,
+			wantMissing:     "",
+		},
+		{
+			name:            "profile omitted",
+			configuredScope: customScope,
+			grantedScopes:   "openid offline_access " + customScope,
+			wantMissing:     "",
+		},
+		{
+			name:            "offline access omitted",
+			configuredScope: customScope,
+			grantedScopes:   "openid profile " + customScope,
+			wantMissing:     "",
+		},
+		{
+			name:            "configured superadmin scope omitted",
+			configuredScope: customScope,
+			grantedScopes:   "openid profile offline_access",
+			wantMissing:     customScope,
+		},
+		{
+			name:          "default legacy superadmin scope granted",
+			grantedScopes: "certwarden:superadmin",
 			wantMissing:   "",
 		},
 		{
-			name:          "bare scope does not satisfy custom scope",
-			grantedScopes: "openid offline_access profile certwarden:superadmin",
-			wantMissing:   customScope,
-		},
-		{
-			name:          "standard scope remains required",
-			grantedScopes: "openid offline_access " + customScope,
-			wantMissing:   "profile",
+			name:            "custom fully qualified scope granted",
+			configuredScope: customScope,
+			grantedScopes:   customScope,
+			wantMissing:     "",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := oidcMissingRequiredScope(test.grantedScopes, oauth2Cfg.Scopes); got != test.wantMissing {
+			requiredScopes := oidcRequiredAuthorizationScopes(test.configuredScope)
+			if got := oidcMissingRequiredScope(test.grantedScopes, requiredScopes); got != test.wantMissing {
 				t.Errorf("expected missing scope %q, got %q", test.wantMissing, got)
 			}
 		})
 	}
+}
+
+func TestOIDCTokenResponseScope(t *testing.T) {
+	tests := []struct {
+		name        string
+		extra       map[string]any
+		wantScope   string
+		wantPresent bool
+		wantValid   bool
+	}{
+		{
+			name:        "scope returned",
+			extra:       map[string]any{"scope": "certwarden:superadmin"},
+			wantScope:   "certwarden:superadmin",
+			wantPresent: true,
+			wantValid:   true,
+		},
+		{
+			name:      "scope omitted",
+			extra:     map[string]any{},
+			wantValid: true,
+		},
+		{
+			name:        "scope returned empty",
+			extra:       map[string]any{"scope": ""},
+			wantPresent: true,
+			wantValid:   true,
+		},
+		{
+			name:        "scope malformed",
+			extra:       map[string]any{"scope": []string{"certwarden:superadmin"}},
+			wantPresent: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			token := new(oauth2.Token).WithExtra(test.extra)
+			gotScope, gotPresent, gotValid := oidcTokenResponseScope(token)
+			if gotScope != test.wantScope {
+				t.Errorf("expected scope %q, got %q", test.wantScope, gotScope)
+			}
+			if gotPresent != test.wantPresent {
+				t.Errorf("expected presence %t, got %t", test.wantPresent, gotPresent)
+			}
+			if gotValid != test.wantValid {
+				t.Errorf("expected validity %t, got %t", test.wantValid, gotValid)
+			}
+		})
+	}
+}
+
+func TestOIDCCallbackValidatesOnlySuperadminAuthorizationScope(t *testing.T) {
+	const customScope = "api://example-app/certwarden:superadmin"
+
+	tests := []struct {
+		name            string
+		configuredScope string
+		responseScope   any
+		wantAuthorized  bool
+	}{
+		{
+			name:            "openid omitted",
+			configuredScope: customScope,
+			responseScope:   "profile offline_access " + customScope,
+			wantAuthorized:  true,
+		},
+		{
+			name:            "profile omitted",
+			configuredScope: customScope,
+			responseScope:   "openid offline_access " + customScope,
+			wantAuthorized:  true,
+		},
+		{
+			name:            "offline access omitted",
+			configuredScope: customScope,
+			responseScope:   "openid profile " + customScope,
+			wantAuthorized:  true,
+		},
+		{
+			name:            "configured superadmin scope omitted",
+			configuredScope: customScope,
+			responseScope:   "openid profile offline_access",
+		},
+		{
+			name:           "default legacy superadmin scope",
+			responseScope:  oidcDefaultSuperadminScope,
+			wantAuthorized: true,
+		},
+		{
+			name:            "custom fully qualified scope",
+			configuredScope: customScope,
+			responseScope:   customScope,
+			wantAuthorized:  true,
+		},
+		{
+			name:            "scope response omitted",
+			configuredScope: customScope,
+			wantAuthorized:  true,
+		},
+		{
+			name:            "scope response empty",
+			configuredScope: customScope,
+			responseScope:   "",
+		},
+		{
+			name:            "scope response malformed",
+			configuredScope: customScope,
+			responseScope:   []string{customScope},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service, state, tokenServer := newOIDCCallbackTestService(t, test.configuredScope, test.responseScope)
+			defer tokenServer.Close()
+
+			response := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, "/callback?state="+state+"&code=provider-code", nil)
+			if errJSON := service.OIDCGetCallback(response, request); errJSON != nil {
+				t.Fatalf("callback returned JSON error: %v", errJSON)
+			}
+
+			_, authorized := service.oidc.pendingSessions.Read(state)
+			if authorized != test.wantAuthorized {
+				t.Errorf("expected authorization result %t, got %t", test.wantAuthorized, authorized)
+			}
+		})
+	}
+}
+
+func TestOIDCRefreshValidatesOnlySuperadminAuthorizationScope(t *testing.T) {
+	const customScope = "api://example-app/certwarden:superadmin"
+
+	tests := []struct {
+		name          string
+		responseScope any
+		wantError     bool
+	}{
+		{
+			name:          "custom superadmin scope only",
+			responseScope: customScope,
+		},
+		{
+			name:          "custom superadmin scope omitted from grant",
+			responseScope: "openid profile offline_access",
+			wantError:     true,
+		},
+		{
+			name: "scope response omitted",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := oidcTestTokenResponse(t, test.responseScope)
+			tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(response); err != nil {
+					t.Errorf("failed to encode token response: %v", err)
+				}
+			}))
+			defer tokenServer.Close()
+
+			ctx := oidc.ClientContext(context.Background(), tokenServer.Client())
+			extraFuncs := &oidcExtraFuncs{
+				ctxWithHttpClient: ctx,
+				cfg: &oauth2.Config{
+					ClientID:     "test-client",
+					ClientSecret: "test-secret",
+					Endpoint:     oauth2.Endpoint{TokenURL: tokenServer.URL},
+				},
+				requiredAuthorizationScopes: oidcRequiredAuthorizationScopes(customScope),
+				idTokenVerifier: oidc.NewVerifier(
+					"https://idp.example.com",
+					nil,
+					&oidc.Config{ClientID: "test-client", InsecureSkipSignatureCheck: true},
+				),
+				token: &expectedToken{RefreshToken: "old-refresh-token"},
+			}
+
+			err := extraFuncs.RefreshCheck()
+			if (err != nil) != test.wantError {
+				t.Fatalf("expected error %t, got %v", test.wantError, err)
+			}
+		})
+	}
+}
+
+func newOIDCCallbackTestService(t *testing.T, configuredScope string, responseScope any) (*Service, string, *httptest.Server) {
+	t.Helper()
+
+	tokenResponse := oidcTestTokenResponse(t, responseScope)
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(tokenResponse); err != nil {
+			t.Errorf("failed to encode token response: %v", err)
+		}
+	}))
+
+	service := new(Service)
+	service.logger = zap.NewNop().Sugar()
+	service.oidc.ctxWithHttpClient = oidc.ClientContext(context.Background(), tokenServer.Client())
+	service.oidc.pendingSessions = safemap.NewSafeMap[*oidcPendingSession]()
+	service.oidc.oauth2Config = &oauth2.Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		RedirectURL:  "https://certwarden.example.com/callback",
+		Endpoint:     oauth2.Endpoint{TokenURL: tokenServer.URL},
+	}
+	service.oidc.requiredAuthorizationScopes = oidcRequiredAuthorizationScopes(configuredScope)
+	service.oidc.idTokenVerifier = oidc.NewVerifier(
+		"https://idp.example.com",
+		nil,
+		&oidc.Config{ClientID: "test-client", InsecureSkipSignatureCheck: true},
+	)
+
+	const state = "test-state"
+	callerRedirectURL, err := url.Parse("https://certwarden.example.com/certwarden/")
+	if err != nil {
+		t.Fatalf("failed to parse caller redirect URL: %v", err)
+	}
+	service.oidc.pendingSessions.Add(state, &oidcPendingSession{
+		callerRedirectUrl: callerRedirectURL,
+		codeVerifierHex:   "test-code-verifier",
+		createdAt:         time.Now(),
+	})
+
+	return service, state, tokenServer
+}
+
+func oidcTestTokenResponse(t *testing.T, responseScope any) map[string]any {
+	t.Helper()
+
+	response := map[string]any{
+		"access_token":  "test-access-token",
+		"refresh_token": "test-refresh-token",
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+		"id_token": oidcTestUnsignedIDToken(t, map[string]any{
+			"iss": "https://idp.example.com",
+			"sub": "test-subject",
+			"aud": "test-client",
+			"exp": time.Now().Add(time.Hour).Unix(),
+		}),
+	}
+	if responseScope != nil {
+		response["scope"] = responseScope
+	}
+
+	return response
+}
+
+func oidcTestUnsignedIDToken(t *testing.T, claims map[string]any) string {
+	t.Helper()
+
+	headerJSON, err := json.Marshal(map[string]string{"alg": "none", "typ": "JWT"})
+	if err != nil {
+		t.Fatalf("failed to marshal ID token header: %v", err)
+	}
+	payloadJSON, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("failed to marshal ID token claims: %v", err)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(headerJSON) + "." +
+		base64.RawURLEncoding.EncodeToString(payloadJSON) + "."
 }

--- a/pkg/domain/app/auth/oidc_test.go
+++ b/pkg/domain/app/auth/oidc_test.go
@@ -1,0 +1,86 @@
+package auth
+
+import (
+	"net/url"
+	"testing"
+
+	"golang.org/x/oauth2"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNewOIDCOAuth2ConfigUsesDefaultSuperadminScope(t *testing.T) {
+	cfg := new(Config)
+	oauth2Cfg := newOIDCOAuth2Config(cfg, oauth2.Endpoint{
+		AuthURL: "https://idp.example.com/authorize",
+	})
+
+	authURL, err := url.Parse(oauth2Cfg.AuthCodeURL("state"))
+	if err != nil {
+		t.Fatalf("failed to parse authorization URL: %v", err)
+	}
+
+	const want = "openid offline_access profile certwarden:superadmin"
+	if got := authURL.Query().Get("scope"); got != want {
+		t.Errorf("expected scope %q, got %q", want, got)
+	}
+}
+
+func TestNewOIDCOAuth2ConfigUsesConfiguredSuperadminScope(t *testing.T) {
+	const customScope = "api://bb61c7e1-3af1-4b35-b0d2-1cbe60913ba2/certwarden:superadmin"
+
+	cfg := new(Config)
+	err := yaml.Unmarshal([]byte("oidc:\n  superadmin_scope: \""+customScope+"\"\n"), cfg)
+	if err != nil {
+		t.Fatalf("failed to parse OIDC configuration: %v", err)
+	}
+
+	oauth2Cfg := newOIDCOAuth2Config(cfg, oauth2.Endpoint{
+		AuthURL: "https://idp.example.com/authorize",
+	})
+	authURL, err := url.Parse(oauth2Cfg.AuthCodeURL("state"))
+	if err != nil {
+		t.Fatalf("failed to parse authorization URL: %v", err)
+	}
+
+	const want = "openid offline_access profile " + customScope
+	if got := authURL.Query().Get("scope"); got != want {
+		t.Errorf("expected scope %q, got %q", want, got)
+	}
+}
+
+func TestOIDCMissingRequiredScopeUsesConfiguredSuperadminScope(t *testing.T) {
+	const customScope = "api://bb61c7e1-3af1-4b35-b0d2-1cbe60913ba2/certwarden:superadmin"
+	cfg := new(Config)
+	cfg.OIDC.SuperadminScope = customScope
+	oauth2Cfg := newOIDCOAuth2Config(cfg, oauth2.Endpoint{})
+
+	tests := []struct {
+		name          string
+		grantedScopes string
+		wantMissing   string
+	}{
+		{
+			name:          "custom scope granted",
+			grantedScopes: "openid offline_access profile " + customScope,
+			wantMissing:   "",
+		},
+		{
+			name:          "bare scope does not satisfy custom scope",
+			grantedScopes: "openid offline_access profile certwarden:superadmin",
+			wantMissing:   customScope,
+		},
+		{
+			name:          "standard scope remains required",
+			grantedScopes: "openid offline_access " + customScope,
+			wantMissing:   "profile",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := oidcMissingRequiredScope(test.grantedScopes, oauth2Cfg.Scopes); got != test.wantMissing {
+				t.Errorf("expected missing scope %q, got %q", test.wantMissing, got)
+			}
+		})
+	}
+}

--- a/pkg/domain/app/auth/service.go
+++ b/pkg/domain/app/auth/service.go
@@ -74,10 +74,11 @@ type Service struct {
 		storage Storage
 	}
 	oidc struct {
-		ctxWithHttpClient context.Context
-		pendingSessions   *safemap.SafeMap[*oidcPendingSession]
-		oauth2Config      *oauth2.Config
-		idTokenVerifier   *oidc.IDTokenVerifier
+		ctxWithHttpClient           context.Context
+		pendingSessions             *safemap.SafeMap[*oidcPendingSession]
+		oauth2Config                *oauth2.Config
+		requiredAuthorizationScopes []string
+		idTokenVerifier             *oidc.IDTokenVerifier
 	}
 }
 
@@ -88,7 +89,7 @@ func newOIDCOAuth2Config(cfg *Config, endpoint oauth2.Endpoint) *oauth2.Config {
 		RedirectURL:  cfg.OIDC.APIRedirectURI,
 
 		Endpoint: endpoint,
-		Scopes:   oidcScopes(cfg.OIDC.SuperadminScope),
+		Scopes:   oidcRequestedScopes(cfg.OIDC.SuperadminScope),
 	}
 }
 
@@ -152,6 +153,7 @@ func NewService(app App, cfg *Config) (*Service, error) {
 
 			// oidc oauth2 config
 			service.oidc.oauth2Config = newOIDCOAuth2Config(cfg, provider.Endpoint())
+			service.oidc.requiredAuthorizationScopes = oidcRequiredAuthorizationScopes(cfg.OIDC.SuperadminScope)
 
 			// ensure redirect parses
 			_, err = url.Parse(service.oidc.oauth2Config.RedirectURL)

--- a/pkg/domain/app/auth/service.go
+++ b/pkg/domain/app/auth/service.go
@@ -54,10 +54,11 @@ type Config struct {
 		Enabled *bool `yaml:"enabled"`
 	} `yaml:"local"`
 	OIDC struct {
-		IssuerURL      string `yaml:"issuer_url"`
-		ClientID       string `yaml:"client_id"`
-		ClientSecret   string `yaml:"client_secret"`
-		APIRedirectURI string `yaml:"api_redirect_uri"`
+		IssuerURL       string `yaml:"issuer_url"`
+		ClientID        string `yaml:"client_id"`
+		ClientSecret    string `yaml:"client_secret"`
+		APIRedirectURI  string `yaml:"api_redirect_uri"`
+		SuperadminScope string `yaml:"superadmin_scope"`
 	} `yaml:"oidc"`
 }
 
@@ -77,6 +78,17 @@ type Service struct {
 		pendingSessions   *safemap.SafeMap[*oidcPendingSession]
 		oauth2Config      *oauth2.Config
 		idTokenVerifier   *oidc.IDTokenVerifier
+	}
+}
+
+func newOIDCOAuth2Config(cfg *Config, endpoint oauth2.Endpoint) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     cfg.OIDC.ClientID,
+		ClientSecret: cfg.OIDC.ClientSecret,
+		RedirectURL:  cfg.OIDC.APIRedirectURI,
+
+		Endpoint: endpoint,
+		Scopes:   oidcScopes(cfg.OIDC.SuperadminScope),
 	}
 }
 
@@ -139,14 +151,7 @@ func NewService(app App, cfg *Config) (*Service, error) {
 			}
 
 			// oidc oauth2 config
-			service.oidc.oauth2Config = &oauth2.Config{
-				ClientID:     cfg.OIDC.ClientID,
-				ClientSecret: cfg.OIDC.ClientSecret,
-				RedirectURL:  cfg.OIDC.APIRedirectURI,
-
-				Endpoint: provider.Endpoint(),
-				Scopes:   oidcRequiredScopes,
-			}
+			service.oidc.oauth2Config = newOIDCOAuth2Config(cfg, provider.Endpoint())
 
 			// ensure redirect parses
 			_, err = url.Parse(service.oidc.oauth2Config.RedirectURL)


### PR DESCRIPTION
  ## Summary

  - Add an optional `auth.oidc.superadmin_scope` configuration field.
  - Preserve `certwarden:superadmin` as the default.
  - Separate scopes requested from the OIDC provider from scopes required for Cert Warden authorization.
  - Continue requesting `openid`, `profile`, and `offline_access`.
  - Require only the configured superadmin scope as the application authorization permission.
  - Apply the same authorization-scope validation during token refresh.

  ## Problem

  Some OIDC providers require custom delegated scopes to be fully qualified.

  For example, Microsoft Entra ID interprets an unqualified custom scope such as:

  `certwarden:superadmin`

  as belonging to Microsoft Graph. A custom application scope instead needs to be requested using its exact resource-qualified value, such as:

  `api://application-id/certwarden:superadmin`

  Cert Warden currently hard-codes the bare scope, preventing these providers from using a fully qualified custom scope.

  The callback also treats every requested scope as an authorization requirement. OIDC protocol scopes such as `openid`, `profile`, and `offline_access` are not guaranteed to appear in an access-token `scope`
  response:

  - `openid` initiates the OIDC authentication flow and is validated through the ID token.
  - `profile` requests standard identity claims.
  - `offline_access` requests refresh-token capability.
  - The Cert Warden superadmin permission is the application authorization requirement.

  ## Implementation

  The OIDC scopes are separated into two sets:

  Requested scopes:

  - `openid`
  - `profile`
  - `offline_access`
  - configured superadmin scope

  Required authorization scopes:

  - configured superadmin scope

  When the provider returns scope metadata, Cert Warden verifies that the configured superadmin scope is present. Protocol scopes are not used as authorization gates.

  If the token response omits its `scope` field, the existing RFC 6749 behavior is preserved: the granted scope is treated as identical to the requested scope.

  The same authorization-scope behavior is used during token refresh.

  ## Configuration

  ```yaml
  auth:
    oidc:
      issuer_url: "https://provider.example.com"
      client_id: "client-id"
      client_secret: "client-secret"
      api_redirect_uri: "https://certwarden.example.com/certwarden/api/v1/app/auth/oidc/callback"
      superadmin_scope: "api://application-id/certwarden:superadmin"
  ```

  ## Backward compatibility

  If `superadmin_scope` is absent or empty, Cert Warden continues to use:

  `certwarden:superadmin`

  Existing users therefore retain the current behavior without changing their configuration.

  This implementation is provider-neutral and does not contain Microsoft Entra-specific logic.

  ## Security

  The change does not alter:

  - issuer validation
  - authorization-code exchange
  - ID-token signature and claim verification
  - state validation
  - PKCE handling
  - the requirement for a Cert Warden superadmin permission

  Only the distinction between OIDC protocol scopes and the application authorization scope changes.

  ## Testing

  Coverage includes:

  - default legacy superadmin scope remains requested
  - configured custom scope is requested exactly
  - `openid` omitted from returned access-token scopes
  - `profile` omitted from returned access-token scopes
  - `offline_access` omitted from returned access-token scopes
  - configured superadmin scope omitted and denied
  - legacy default scope accepted
  - fully qualified custom scope accepted
  - malformed returned scope rejected
  - callback behavior through a real OAuth token exchange
  - refresh-token scope validation

  Verification performed:

  ```text
  go test ./pkg/domain/app/auth -count=1
  go test -race ./pkg/domain/app/auth -count=1
  go test ./... -count=1
  go vet ./pkg/domain/app/auth
  go build ./cmd/api-server
  git diff --check
  ```