### PR TITLE
Fix idle order status endpoints returning internal errors

### DIFF
--- a/pkg/domain/orders/handlers_get_fulfilling.go
+++ b/pkg/domain/orders/handlers_get_fulfilling.go
@@ -39,12 +39,16 @@ func (service *Service) GetFulfillWorkStatus(w http.ResponseWriter, r *http.Requ
 		orderIDs = append(orderIDs, mgrWaitingJob.orderID)
 	}
 
-	// lookup all orders in db
-	orders, err := service.storage.GetOrders(orderIDs)
-	if err != nil {
-		err = fmt.Errorf("orders: failed to convert fulfilling jobs to order objects (%w)", err)
-		service.logger.Error(err)
-		return output.ErrorJsonErrInternal(err)
+	// lookup all orders in db, if any jobs exist
+	orders := []*Order{}
+	var err error
+	if len(orderIDs) > 0 {
+		orders, err = service.storage.GetOrders(orderIDs)
+		if err != nil {
+			err = fmt.Errorf("orders: failed to convert fulfilling jobs to order objects (%w)", err)
+			service.logger.Error(err)
+			return output.ErrorJsonErrInternal(err)
+		}
 	}
 
 	// build working part of response

--- a/pkg/domain/orders/handlers_get_post_process.go
+++ b/pkg/domain/orders/handlers_get_post_process.go
@@ -23,12 +23,16 @@ func (service *Service) GetPostProcessWorkStatus(w http.ResponseWriter, r *http.
 		orderIDs = append(orderIDs, mgrWaitingJob.orderID)
 	}
 
-	// lookup all orders in db
-	orders, err := service.storage.GetOrders(orderIDs)
-	if err != nil {
-		err = fmt.Errorf("orders: failed to convert post process jobs to order objects (%w)", err)
-		service.logger.Error(err)
-		return output.ErrorJsonErrInternal(err)
+	// lookup all orders in db, if any jobs exist
+	orders := []*Order{}
+	var err error
+	if len(orderIDs) > 0 {
+		orders, err = service.storage.GetOrders(orderIDs)
+		if err != nil {
+			err = fmt.Errorf("orders: failed to convert post process jobs to order objects (%w)", err)
+			service.logger.Error(err)
+			return output.ErrorJsonErrInternal(err)
+		}
 	}
 
 	// build working part of response

--- a/pkg/domain/orders/handlers_get_work_status_test.go
+++ b/pkg/domain/orders/handlers_get_work_status_test.go
@@ -1,0 +1,105 @@
+package orders
+
+import (
+	"certwarden-backend/pkg/datatypes/job_manager"
+	"certwarden-backend/pkg/output"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+type idleWorkStatusStorage struct {
+	Storage
+}
+
+func (idleWorkStatusStorage) GetOrders(_ []int) ([]*Order, error) {
+	return nil, sql.ErrNoRows
+}
+
+type workStatusOutputApp struct {
+	logger *zap.SugaredLogger
+}
+
+func (app workStatusOutputApp) GetLogger() *zap.SugaredLogger {
+	return app.logger
+}
+
+func TestIdleWorkStatusHandlersReturnEmptyStatus(t *testing.T) {
+	service := newIdleWorkStatusTestService(t)
+
+	tests := []struct {
+		name    string
+		handler func(http.ResponseWriter, *http.Request) *output.JsonError
+	}{
+		{
+			name:    "fulfilling",
+			handler: service.GetFulfillWorkStatus,
+		},
+		{
+			name:    "post processing",
+			handler: service.GetPostProcessWorkStatus,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, "/status", nil)
+
+			if errJSON := test.handler(response, request); errJSON != nil {
+				t.Fatalf("idle status returned an error: %v", errJSON)
+			}
+			if response.Code != http.StatusOK {
+				t.Fatalf("expected status %d, got %d", http.StatusOK, response.Code)
+			}
+
+			var body orderWorkStatusResponse
+			if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if body.Message != "ok" {
+				t.Errorf("expected message %q, got %q", "ok", body.Message)
+			}
+			if len(body.JobsWaiting) != 0 {
+				t.Errorf("expected no waiting jobs, got %d", len(body.JobsWaiting))
+			}
+			for workerID, job := range body.JobsWorking {
+				if job != nil {
+					t.Errorf("expected worker %d to be idle", workerID)
+				}
+			}
+		})
+	}
+}
+
+func newIdleWorkStatusTestService(t *testing.T) *Service {
+	t.Helper()
+
+	logger := zap.NewNop().Sugar()
+	outputService, err := output.NewService(workStatusOutputApp{logger: logger})
+	if err != nil {
+		t.Fatalf("failed to create output service: %v", err)
+	}
+
+	shutdownContext, cancel := context.WithCancel(context.Background())
+	shutdownWaitGroup := new(sync.WaitGroup)
+	t.Cleanup(func() {
+		cancel()
+		shutdownWaitGroup.Wait()
+	})
+
+	return &Service{
+		logger:          logger,
+		output:          outputService,
+		storage:         idleWorkStatusStorage{},
+		postProcessing:  job_manager.NewManager[*postProcessJob](1, "test post processing", shutdownContext, shutdownWaitGroup, logger),
+		orderFulfilling: job_manager.NewManager[*orderFulfillJob](1, "test order fulfilling", shutdownContext, shutdownWaitGroup, logger),
+		shutdownContext: shutdownContext,
+	}
+}


### PR DESCRIPTION
  ## Summary

  Fix the fulfilling and post-processing status endpoints returning HTTP 500 when their job queues are idle.

  Both endpoints now skip the order storage lookup when there are no job IDs and return their existing HTTP 200 empty status response.

  ## Problem

  The work-status handlers collect the order IDs for active and waiting jobs and pass them to `Storage.GetOrders`.

  When all workers are idle and no jobs are waiting, the resulting ID slice is empty:

  ```text
  orderIDs = []
  ```

  After `GetOrders` was changed to return `sql.ErrNoRows` when a query produces no orders, the handlers began treating this normal idle state as an internal error:

  ```text
  orders: failed to convert fulfilling jobs to order objects
  (sql: no rows in result set)

  orders: failed to convert post process jobs to order objects
  (sql: no rows in result set)
  ```

  Because the frontend regularly polls these endpoints, an idle Cert Warden instance produces repeated HTTP 500 responses and error logs.

  ## Implementation

  Both handlers now call `GetOrders` only when `len(orderIDs) > 0`.

  When the queue is empty, they continue building the normal response directly:

  - HTTP status `200`
  - message `"ok"`
  - idle workers represented as `null`
  - empty waiting-job array

  Storage behavior itself is unchanged.

  Errors from `GetOrders` remain strict when the handler has one or more job IDs. The fix therefore does not conceal stale queue entries or missing database orders.

  ## Scope

  Changed handlers:

  - fulfilling work status
  - post-processing work status

  No order creation, fulfillment, post-processing, storage, or auto-ordering behavior is otherwise changed.

  ## Testing

  A handler-level regression test covers both endpoints using idle job managers and a storage implementation that returns `sql.ErrNoRows` if called.

  The test failed against the previous implementation with the reported HTTP 500 error and passes after the guarded lookup was added.

  Verification performed:

  ```text
  go test ./pkg/domain/orders -run TestIdleWorkStatusHandlersReturnEmptyStatus -count=1
  go test -race ./pkg/domain/orders -count=1
  go test ./... -count=1
  go vet ./pkg/domain/orders
  go build ./cmd/api-server
  git diff --check
  ```